### PR TITLE
Fire off a generic event to indicate that the addon is fully loaded 

### DIFF
--- a/ForgeUI_Inventory/ForgeUI_InventoryBag.lua
+++ b/ForgeUI_Inventory/ForgeUI_InventoryBag.lua
@@ -270,6 +270,7 @@ function ForgeUI_Inventory:ForgeAPI_AfterRegistration()
 
 	self.wndIconBtnSortDropDown = self.wndMain:FindChild("OptionsContainer:OptionsContainerFrame:OptionsConfigureSort:IconBtnSortDropDown")
 	self.wndIconBtnSortDropDown:AttachWindow(self.wndIconBtnSortDropDown:FindChild("ItemSortPrompt"))
+	Event_FireGenericEvent("AddonFullyLoaded", {addon = self, strName = self.strAddonName})
 end
 
 function ForgeUI_Inventory:ForgeAPI_AfterRestore()


### PR DESCRIPTION
Could this be inserted to allow integration from SenorPlow?