### PR TITLE
Add ability to move the location of the Breath/Hazard bars

### DIFF
--- a/ForgeUI_Hazards/ForgeUI_Hazards.lua
+++ b/ForgeUI_Hazards/ForgeUI_Hazards.lua
@@ -73,6 +73,7 @@ function ForgeUI_Hazards:ForgeAPI_AfterRegistration()
 	Apollo.RegisterEventHandler("HazardUpdated", "OnHazardsUpdated", self)
 	
 	self.wndHazardsHolder = Apollo.LoadForm(self.xmlDoc, "HazardsHolder", ForgeUI.HudStratum3, self)
+	ForgeUI.API_RegisterWindow(self, self.wndHazardsHolder, "ForgeUI_HazardMeter", { strDisplayName = "Breath and Hazard bars" })
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Registers the HazardsHolder window so it can be moved during 'Unlock
Elements.' Tested and it both allows movement, and saves on reloadui.