### PR TITLE
add max height of 10 mounts for popup window

### DIFF
--- a/ForgeUI_ActionBars/ForgeUI_ActionBars.lua
+++ b/ForgeUI_ActionBars/ForgeUI_ActionBars.lua
@@ -318,7 +318,7 @@ function ForgeUI_ActionBars:FillMounts(wnd)
         local nCount = 0
         for idx, tMount in pairs(tMountList) do
                 if tMount.bIsKnown then
-                        nCount = nCount + 1
+                        if nCount < 10 then nCount = nCount + 1 end
                        
                         local tSpellObject = tMount.splObject
        


### PR DESCRIPTION
Fixes #200 

This makes the mount list have a max height of 10 mount icons. If they have more than 10 mounts it will then become a scroll-able window.

The 10 there just seemed like a good number. That could easily be changed. Making it user configurable doesn't seem worth it, but could be done with more work.