### PR TITLE
Core - ForgeAPI_ProfileChanged

### DIFF
--- a/ForgeUI/core/addon.lua
+++ b/ForgeUI/core/addon.lua
@@ -65,5 +65,6 @@ function Prototype:ForgeAPI_PreInit() end
 function Prototype:ForgeAPI_Init() end
 function Prototype:ForgeAPI_LoadSettings() end
 function Prototype:ForgeAPI_PopulateOptions() end
+function Prototype:ForgeAPI_ProfileChanged() end
 
 _G["ForgeLibs"]["ForgeAddon"] = new(Addon)

--- a/ForgeUI/core/core.lua
+++ b/ForgeUI/core/core.lua
@@ -103,6 +103,10 @@ function Core:OnDatabaseUpdate()
 		v.tAddon:RefreshConfig()
 	end
 
+	for _, v in pairs(tAddons) do
+		v.tAddon:ForgeAPI_ProfileChanged()
+	end
+
 	ForgeUI:CollapseAllMenuItems()
 end
 


### PR DESCRIPTION
ProfileChanged API call that is fired after all the addons finished loading their profile settings. Usefull for cross-addon functionality where ForgeAPI_LoadSettings is not reliable.