### PR TITLE
Cleanup global variables

### DIFF
--- a/ForgeUI/core/util.lua
+++ b/ForgeUI/core/util.lua
@@ -71,6 +71,7 @@ end
 
 function Util:ShortNum(num)
 	local tmp = tostring(num)
+	local ret
     if not num then
         return 0
     elseif num >= 1000000 then

--- a/ForgeUI/interface/gui.lua
+++ b/ForgeUI/interface/gui.lua
@@ -302,7 +302,7 @@ function Gui:API_AddCheckBox(tModule, wnd, strText, tSettings, strKey, tOptions)
 		end
 
 		if tOptions.nAddWidth then
-			nLeft, nTop, nRight, nBottom = wndCheckBox:GetAnchorOffsets()
+			local nLeft, nTop, nRight, nBottom = wndCheckBox:GetAnchorOffsets()
 			wndCheckBox:SetAnchorOffsets(nLeft, nTop, nRight + tOptions.nAddWidth, nBottom)
 		end
 

--- a/ForgeUI_CastBars/ForgeUI_CastBars.lua
+++ b/ForgeUI_CastBars/ForgeUI_CastBars.lua
@@ -373,8 +373,8 @@ end
 
 function ForgeUI_CastBars:UpdateInterruptArmor(unit, wnd, strType)
 	local bShow = false
-	nValue = unit:GetInterruptArmorValue()
-	nMax = unit:GetInterruptArmorMax()
+	local nValue = unit:GetInterruptArmorValue()
+	local nMax = unit:GetInterruptArmorMax()
 	if nMax == 0 or nValue == nil or unit:IsDead() then
 		wnd:FindChild("CastBar"):SetBarColor(self._DB.profile.tFrames[strType].crCastBar)
 	else

--- a/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
+++ b/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
@@ -61,6 +61,8 @@ local fnDrawRewards
 local fnDrawCastBar
 local fnDrawIndicators
 local fnDrawInfo
+local fnDrawNameplate
+local fnDrawMOOBar
 
 local fnColorNameplate
 

--- a/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
+++ b/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
@@ -885,8 +885,8 @@ function ForgeUI_Nameplates:DrawIA(tNameplate)
 
 	local bShow = false
 
-	nValue = unitOwner:GetInterruptArmorValue()
-	nMax = unitOwner:GetInterruptArmorMax()
+	local nValue = unitOwner:GetInterruptArmorValue()
+	local nMax = unitOwner:GetInterruptArmorMax()
 	if nMax == 0 or nValue == nil or unitOwner:IsDead() then
 
 	else

--- a/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
+++ b/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
@@ -16,7 +16,7 @@ require "Window"
 -----------------------------------------------------------------------------------------------
 -- Constants
 -----------------------------------------------------------------------------------------------
-krtClassEnums = {
+local krtClassEnums = {
 	[GameLib.CodeEnumClass.Warrior]         = "Warrior",
 	[GameLib.CodeEnumClass.Engineer]        = "Engineer",
 	[GameLib.CodeEnumClass.Esper]           = "Esper",
@@ -25,7 +25,7 @@ krtClassEnums = {
 	[GameLib.CodeEnumClass.Spellslinger]    = "Spellslinger"
 }
 
-krtNpcRankEnums = {
+local krtNpcRankEnums = {
 	[Unit.CodeEnumRank.Elite]       = "elite",
 	[Unit.CodeEnumRank.Superior]    = "superior",
 	[Unit.CodeEnumRank.Champion]    = "champion",
@@ -34,13 +34,13 @@ krtNpcRankEnums = {
 	[Unit.CodeEnumRank.Fodder]      = "fodder",
 }
 
-krtIAStyles = {
+local krtIAStyles = {
 	["ForgeUI_shield"] = { bDynamicSprite = false, crInf = "FF2D2D2D", crValue = "FF795548" },
 	["ForgeUI_Border"] = { bDynamicSprite = false, crInf = "FF2D2D2D", crValue = "FF795548" },
 	["ForgeUI_Carbine"] = { bDynamicSprite = true, strSpriteInf = "ForgeUI_ia_inf_set1", strSpriteValue = "ForgeUI_ia_set1", crInf = "ffffffff", crValue = "ffffffff" },
 }
 
-tNameSwaps = {
+local tNameSwaps = {
 	["Briex Sper"] = "Pink Cheese",
 }
 

--- a/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
+++ b/ForgeUI_Nameplates/ForgeUI_Nameplates.lua
@@ -1357,14 +1357,13 @@ function ForgeUI_Nameplates:CheckDrawDistance(tNameplate)
 	local nDeltaZ = tPosTarget.z - tPosPlayer.z
 
 	local nDistance = (nDeltaX * nDeltaX) + (nDeltaY * nDeltaY) + (nDeltaZ * nDeltaZ)
-
+	local bInRange
 	if tNameplate.bIsTarget then
 		bInRange = nDistance < self._DB.profile.knTargetRange
-		return bInRange
 	else
 		bInRange = nDistance < self._DB.profile.nMaxRange * self._DB.profile.nMaxRange
-		return bInRange
 	end
+	return bInRange
 end
 
 function ForgeUI_Nameplates:HelperVerifyVisibilityOptions(tNameplate)

--- a/ForgeUI_PetFrames/ForgeUI_PetFrames.lua
+++ b/ForgeUI_PetFrames/ForgeUI_PetFrames.lua
@@ -25,7 +25,7 @@ local ForgeUI_PetFrames = {
 -----------------------------------------------------------------------------------------------
 -- Constants
 -----------------------------------------------------------------------------------------------
-tEngineerStances = {
+local tEngineerStances = {
 	[0] = "",
 	[1] = Apollo.GetString("EngineerResource_Aggro"),
 	[2] = Apollo.GetString("EngineerResource_Defend"),

--- a/ForgeUI_ResourceBars/ForgeUI_ResourceBars.lua
+++ b/ForgeUI_ResourceBars/ForgeUI_ResourceBars.lua
@@ -71,7 +71,7 @@ local ForgeUI_ResourceBars = {
 -----------------------------------------------------------------------------------------------
 -- Constants
 -----------------------------------------------------------------------------------------------
-tPowerLinkId = {
+local tPowerLinkId = {
 	[79798] = true,
 	[79797] = true,
 	[79796] = true,
@@ -83,7 +83,7 @@ tPowerLinkId = {
 	[79787] = true,
 }
 
-tAugBladeBuffId = {
+local tAugBladeBuffId = {
 	[49311] = true,
 	[49310] = true,
 	[49309] = true,
@@ -95,7 +95,7 @@ tAugBladeBuffId = {
 	[46935] = true,
 }
 
-tAugBladeDrainId = {
+local tAugBladeDrainId = {
 	[79757] = true,
 }
 

--- a/ForgeUI_UnitFrames/ForgeUI_UnitFrames.lua
+++ b/ForgeUI_UnitFrames/ForgeUI_UnitFrames.lua
@@ -182,7 +182,7 @@ end
 -- On next frame
 -----------------------------------------------------------------------------------------------
 function ForgeUI_UnitFrames:OnNextFrame()
-	unitPlayer = GetPlayerUnit()
+	local unitPlayer = GetPlayerUnit()
 	if unitPlayer == nil or not unitPlayer then return end
 
 	self:UpdatePlayerFrame(unitPlayer)
@@ -499,7 +499,7 @@ function ForgeUI_UnitFrames:RefreshStyle(unit, name, hpBar, strType)
 end
 
 function ForgeUI_UnitFrames:UpdateStyle_PlayerFrame()
-	unit = GetPlayerUnit()
+	local unit = GetPlayerUnit()
 	if not unit or not self.wndPlayerFrame then return end
 
 	local strName = unit:GetName()

--- a/ForgeUI_UnitFrames/ForgeUI_UnitFrames.lua
+++ b/ForgeUI_UnitFrames/ForgeUI_UnitFrames.lua
@@ -376,8 +376,8 @@ end
 
 -- interrupt armor
 function ForgeUI_UnitFrames:UpdateInterruptArmor(unit, wnd)
-	nValue = unit:GetInterruptArmorValue()
-	nMax = unit:GetInterruptArmorMax()
+	local nValue = unit:GetInterruptArmorValue()
+	local nMax = unit:GetInterruptArmorMax()
 	if nMax == 0 or nValue == nil or unit:IsDead() then
 		wnd:FindChild("InterruptArmor"):Show(false, true)
 	else


### PR DESCRIPTION
Constants in Nameplates, Petframes and
ResourceBars were global instead of local.